### PR TITLE
Specify output file on command line

### DIFF
--- a/Maestro/src/Maestro/Maestro.java
+++ b/Maestro/src/Maestro/Maestro.java
@@ -2,18 +2,69 @@ package Maestro;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.logging.Logger;
+import java.util.logging.Level;
 
+/**
+ * Specifies a program that continuously checks for the existence of a file,
+ * creating it if it doesn't exist.
+ *
+ */
 public class Maestro {
+	private static final Logger LOGGER = Logger.getLogger(Maestro.class.getName());
+	private static File outputFile;
 
-	public static void main(String[] args) throws IOException {
-		System.out.println("hi");
-		while(true){
-			if(new File("C:/Users/k1076631/craftyworkspace/CRAFTY_TemplateCoBRA/data/updated.txt").isFile()){
-				
-			}
-			else{
-				File file = new File("C:/Users/k1076631/craftyworkspace/CRAFTY_TemplateCoBRA/data/updated.txt");
-				file.createNewFile();
+	/**
+	 * Checks to see if a file specified as a command-line argument exists at 0.5
+	 * second intervals. Creates the file if it does not exist.
+	 * 
+	 * @param args Command-line arguments. Should contain the path to the file to be
+	 *             created as a single argument.
+	 * @throws IOException          If the specified file cannot be created.
+	 * @throws InterruptedException Thrown if execution of Maestro Solo is
+	 *                              interrupted while waiting for next check of the
+	 *                              target file's existence.
+	 */
+	public static void main(String[] args) throws IOException, InterruptedException {
+		LOGGER.info("Maestro Solo has started");
+		validateArgs(args);
+		outputFile = new File(args[0]);
+		while (true) {
+			createFileIfItDoesNotExist(outputFile);
+			Thread.sleep(500);
+		}
+	}
+
+	/**
+	 * Basic check of command-line arguments. Exits the program if no arguments are
+	 * given.
+	 * 
+	 * @param args Arguments that were passed to {@code main}
+	 */
+	private static void validateArgs(String[] args) {
+		if (args.length == 0) {
+			LOGGER.log(Level.SEVERE, "No output file specified to Maestro Solo. Stopping.");
+			System.exit(1);
+		}
+		if (args.length > 1) {
+			LOGGER.warning("More than one argument was passed to Maestro Solo. "
+					+ "All but the first argument will be ignored.");
+		}
+	}
+
+	/**
+	 * Create a file if it does not already exist.
+	 * 
+	 * @param file File to create if it does not already exist.
+	 * @throws IOException
+	 */
+	private static void createFileIfItDoesNotExist(File file) throws IOException {
+		if (!outputFile.isFile()) {
+			try {
+				outputFile.createNewFile();
+			} catch (IOException e) {
+				LOGGER.log(Level.SEVERE, "Could not create file " + outputFile);
+				throw e;
 			}
 		}
 	}


### PR DESCRIPTION
Previously the output file that Maestro Solo continuously generates was hard coded into the application. This file must now be specified as a command-line argument, making the application useful on other file systems.

We have also added a 500 ms delay between checks to see if the monitored file exists (NB `Thread.sleep(500)' on line 34). This is done for performance reasons since not including a delay demands a lot of CPU and disk i/o. We reason that even without an explicit delay, these checks are periodic with a frequency set by the CPU's clock speed. @jamesdamillington what do you think? 

Fixes #1 