### PR TITLE
Document build and usage instructions

### DIFF
--- a/Maestro/build.xml
+++ b/Maestro/build.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project basedir="." default="build" name="Maestro">
+    <property environment="env"/>
+    <property name="debuglevel" value="source,lines,vars"/>
+    <property name="target" value="1.8"/>
+    <property name="source" value="1.8"/>
+    <path id="Maestro.classpath">
+        <pathelement location="bin"/>
+    </path>
+    <target name="init">
+        <mkdir dir="bin"/>
+        <copy includeemptydirs="false" todir="bin">
+            <fileset dir="src">
+                <exclude name="**/*.launch"/>
+                <exclude name="**/*.java"/>
+            </fileset>
+        </copy>
+    </target>
+    <target name="clean">
+        <delete dir="bin"/>
+    </target>
+    <target depends="clean" name="cleanall"/>
+    <target depends="build-subprojects,build-project" name="build"/>
+    <target name="build-subprojects"/>
+    <target depends="init" name="build-project">
+        <echo message="${ant.project.name}: ${ant.file}"/>
+        <javac debug="true" debuglevel="${debuglevel}" destdir="bin" includeantruntime="false" source="${source}" target="${target}">
+            <src path="src"/>
+            <classpath refid="Maestro.classpath"/>
+        </javac>
+    </target>
+</project>

--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
 # Maestro_Solo
-Dummy application used with CRAFTY Brazil (so simulate presence of BioLUC model)
+Dummy application used with [CRAFTY Brazil][crafty-brazil] (so simulate presence of BioLUC model)
+
+## Building
+
+To build the application, use `ant` to compile the sources
+
+```bash
+cd Maestro
+ant clean && ant
+```
+
+## Running
+
+To run the application, first set the environment variables
+
+```bash
+MAESTRO_SOLO_HOME=/path/to/Maestro_Solo
+CRAFTY_BRAZIL_HOME=/path/to/CRAFTY_TemplateCoBRA
+```
+
+Suppose we want to use Meastro Solo to continuously check that the file `data/updated.txt` within the CRAFTY Brazil directory exists, and recreate it if necessary. This can be achieved by running
+
+```bash
+java -cp $MAESTRO_SOLO_HOME/Maestro/bin/ \
+    Maestro.Maestro $CRAFTY_BRAZIL_HOME/data/updated.txt
+```
+
+[crafty-brazil]: https://github.com/jamesdamillington/CRAFTY_Brazil


### PR DESCRIPTION
Users should be able to determine how to build and use the code in this repository from the README.

This PR adds specific instructions that should enable users to build the application, and use it in conjunction with [CRAFTY Brazil](https://github.com/jamesdamillington/CRAFTY_Brazil).

We also provide an `ant` build script that simplifies building the project. The consistent use of build tools like this will be useful when deploying inside a Docker container.